### PR TITLE
chore: configurator styling improvements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import axios from "axios";
-import Cookies from "js-cookie";
+import Cookies from "js-cookie"; // i realize we are using both react-cookie and js-cookie
 import React, { useState } from "react";
+import { CookiesProvider } from "react-cookie";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import "./App.css";
 import { BackendUrlProvider } from "./components/BackendUrl.jsx";
@@ -33,21 +34,23 @@ export default function App() {
   });
   return (
     <BackendUrlProvider backendUrlData={BACKEND_URL}>
-      <Router>
-        <Routes>
-          <Route path="/" element={<Landing user={user} />} />
-          <Route path="/login" element={<Login setUser={setUser} />} />
-          <Route path="/signup" element={<Signup />} />
-          <Route path="/clicky" element={<ClickyConfigurator />} />
-          <Route path="/models" element={<Models />} />
-          <Route path="/model" element={<SingleModel />} />
-          <Route path="/cart-checkout" element={<CartCheckoutPage />} />
-          <Route path="/success-checkout" element={<SuccessCheckoutPage />} />
-          <Route element={<PrivateRoutes />}>
-            {/* all protected routes here */}
-          </Route>
-        </Routes>
-      </Router>
+      <CookiesProvider>
+        <Router>
+          <Routes>
+            <Route path="/" element={<Landing user={user} />} />
+            <Route path="/login" element={<Login setUser={setUser} />} />
+            <Route path="/signup" element={<Signup />} />
+            <Route path="/clicky" element={<ClickyConfigurator />} />
+            <Route path="/models" element={<Models />} />
+            <Route path="/model" element={<SingleModel />} />
+            <Route path="/cart-checkout" element={<CartCheckoutPage />} />
+            <Route path="/success-checkout" element={<SuccessCheckoutPage />} />
+            <Route element={<PrivateRoutes />}>
+              {/* all protected routes here */}
+            </Route>
+          </Routes>
+        </Router>
+      </CookiesProvider>
     </BackendUrlProvider>
   );
 }

--- a/src/components/SaveButton.jsx
+++ b/src/components/SaveButton.jsx
@@ -1,0 +1,4 @@
+export default function SaveButton(props) {
+  const { onClickFunction } = props;
+  return <button onClick={onClickFunction}>Save your Custom</button>;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -34,11 +34,12 @@ body,
   height: 100vh;
 }
 
-/* .picker {
-  currently bugged out - cannot select colour when position is absolute
+.picker {
   position: absolute !important;
   top: 74px;
   left: 70px;
-  width: 90px !important;
-  height: 90px !important;
-} */
+  width: 160px !important;
+  height: 160px !important;
+  z-index: 3; /* required to make colour picker selectable, else it is rendered below the 3d canvas*/
+  font-size: large;
+}

--- a/src/pages/ClickyConfigurator.jsx
+++ b/src/pages/ClickyConfigurator.jsx
@@ -36,19 +36,20 @@ function ClickyConfigurator() {
     let prevCookieValues = cookies["saved-models"]
     // cookies are stored as an object
     // access a specific cookie by using its key/name, e.g. cookies["saved-models"]
-    // general format of the saved-models cookie should be an object
+    // general format of the saved-models cookie should be an object, with first layer key being the model ID
     // e.g.
     // {
-    //   clicky: {
+    //   1: {
     //     Case_A_v3: "#b8e986";
     //     Case_B_v4: "indianred";
     //     Spring_Normal: "darkmagenta";
     //     Wheel_40T: "lightblue";
     //   }
-    //   flowerpot: {
+    //   2: {
     //     pot: "indianred";
     //   }
     // }
+    
     setCookie("saved-models", { ...prevCookieValues, 1: modelState.items }) // assume clicky has a model ID of 1
     // setCookie("saved-models", { ...prevCookieValues, clicky2: modelState.items })
     // the line above is to test saving multiple instances of the same model in the saved-models cookie
@@ -70,6 +71,7 @@ function ClickyConfigurator() {
             modelState.items[modelState.currentItem] = color.hex;
           }}
         />
+        <SaveButton onClickFunction={handleModelSave} />
       </div>
     );
   }
@@ -92,7 +94,6 @@ function ClickyConfigurator() {
   return (
     <div style={{ width: "100%", height: "100%" }}>
       <Picker />
-      <SaveButton onClickFunction={handleModelSave} />
       {/* <ColorState /> */}
       <Canvas>
         <PerspectiveCamera makeDefault fov={75} position={[0, 0, 50]} />

--- a/src/pages/ClickyConfigurator.jsx
+++ b/src/pages/ClickyConfigurator.jsx
@@ -6,7 +6,9 @@ import {
 import { Canvas } from "@react-three/fiber";
 import { useState } from "react";
 import { SketchPicker } from "react-color";
+import { useCookies } from "react-cookie";
 import Clicky from "../components/Clicky.jsx";
+import SaveButton from "../components/SaveButton.jsx";
 
 const initialModelState = {
   currentItem: null,
@@ -20,6 +22,7 @@ const initialModelState = {
 
 function ClickyConfigurator() {
   const [modelState, setModelState] = useState(initialModelState);
+  const [cookies, setCookie] = useCookies(["saved-models"]);
 
   const getModelStateFromComponents = () => {
     return modelState;
@@ -28,6 +31,30 @@ function ClickyConfigurator() {
   const sendActiveModelToApp = (stateObj, modelNameStr) => {
     setModelState({ ...stateObj, currentItem: modelNameStr });
   };
+
+  function handleModelSave() {
+    let prevCookieValues = cookies["saved-models"]
+    // cookies are stored as an object
+    // access a specific cookie by using its key/name, e.g. cookies["saved-models"]
+    // general format of the saved-models cookie should be an object
+    // e.g.
+    // {
+    //   clicky: {
+    //     Case_A_v3: "#b8e986";
+    //     Case_B_v4: "indianred";
+    //     Spring_Normal: "darkmagenta";
+    //     Wheel_40T: "lightblue";
+    //   }
+    //   flowerpot: {
+    //     pot: "indianred";
+    //   }
+    // }
+    setCookie("saved-models", { ...prevCookieValues, 1: modelState.items }) // assume clicky has a model ID of 1
+    // setCookie("saved-models", { ...prevCookieValues, clicky2: modelState.items })
+    // the line above is to test saving multiple instances of the same model in the saved-models cookie
+    console.log("saved-models", cookies["saved-models"]);
+    return;
+  }
 
   function Picker() {
     return (
@@ -49,7 +76,6 @@ function ClickyConfigurator() {
 
   function ColorState() {
     const objEntries = Object.entries(modelState.items);
-
     return (
       <div>
         {objEntries.map((subArr) => {
@@ -66,6 +92,7 @@ function ClickyConfigurator() {
   return (
     <div style={{ width: "100%", height: "100%" }}>
       <Picker />
+      <SaveButton onClickFunction={handleModelSave} />
       {/* <ColorState /> */}
       <Canvas>
         <PerspectiveCamera makeDefault fov={75} position={[0, 0, 50]} />


### PR DESCRIPTION
## Changes
- added absolute positioning and z-layers for colour picker
- grouped model-related information (part name, colour picker, save button) into its own component

## How to test
- navigate to the [clicky configurator page](http://localhost:3000/clicky) and ensure that the rendered model remains static when the picker pops in (previously, the model would shift down when the picker appeared in a non-absolute position)

## Known Issues
- N/A

## Screenshots (if any)
- Screenshots of features, before/after
