### PR TITLE
chore: profile icon when login + logout menu item

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -3,21 +3,120 @@ import {
   Box,
   Button,
   Flex,
+  Icon,
   IconButton,
   Image,
   Link,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
   Popover,
   PopoverTrigger,
   Stack,
   useColorModeValue,
   useDisclosure,
 } from "@chakra-ui/react";
+import axios from "axios";
+import { useContext, useState } from "react";
+import { useCookies } from "react-cookie";
+import { BiUser } from "react-icons/bi";
 import { useNavigate } from "react-router-dom";
+import BackendUrlContext from "../components/BackendUrl.jsx";
 import CartDrawer from "../components/cart/CartDrawer";
+
+const CartLogout = ({ onLogoutClick }) => {
+  return (
+    <Stack
+      flex={{ base: 1, md: 0 }}
+      justify="flex-end"
+      direction="row"
+      spacing={3}
+    >
+      <CartDrawer />
+      <Menu>
+        <MenuButton
+          borderRadius={6}
+          color="gray.800"
+          bg="#FF8BA0"
+          padding={"5px 20px 5px 20px"}
+          _hover={{
+            bg: "#FFBECA",
+          }}
+        >
+          <Icon w={7} h={7} as={BiUser} />
+        </MenuButton>
+        <MenuList>
+          <MenuItem color="gray.800">Profile</MenuItem>
+          <MenuItem color="gray.800">Orders</MenuItem>
+          <MenuItem color="gray.800" onClick={onLogoutClick}>
+            Logout
+          </MenuItem>
+        </MenuList>
+      </Menu>
+    </Stack>
+  );
+};
+
+const CartLoginSignup = () => {
+  return (
+    <Stack
+      flex={{ base: 1, md: 0 }}
+      justify="flex-end"
+      direction="row"
+      spacing={3}
+    >
+      <CartDrawer />
+      <Button
+        as="a"
+        fontSize="sm"
+        fontWeight={600}
+        variant="link"
+        href="/login"
+        bg={""}
+        color={"gray.800"}
+        padding={"5px 20px 5px 20px"}
+        _hover={{
+          bg: "whiteAlpha.500",
+        }}
+      >
+        Login
+      </Button>
+      <Button
+        as="a"
+        href="/signup"
+        display={{ base: "none", md: "inline-flex" }}
+        fontSize="sm"
+        fontWeight={600}
+        color="gray.800"
+        bg=""
+        _hover={{
+          bg: "whiteAlpha.500",
+        }}
+      >
+        Sign Up
+      </Button>
+    </Stack>
+  );
+};
 
 export default function NavBar() {
   const { isOpen, onToggle } = useDisclosure();
   const navigate = useNavigate();
+  const [cookies, setCookie] = useCookies(["loggedInUser"]);
+  const { backendUrl } = useContext(BackendUrlContext);
+
+  const [isLoggedIn, setIsLoggedIn] = useState(!!cookies.loggedInHash); // if cookies.loggedInHash is empty string or undefined == false
+
+  const onLogoutClick = () => {
+    axios
+      .post(`${backendUrl}/api/logout`)
+      .then((res) => {
+        navigate(res.data.redirect);
+        setIsLoggedIn(false);
+      })
+      .catch((err) => console.log("[ERROR] failed to logout, err:", err));
+  };
 
   return (
     <Box>
@@ -88,44 +187,12 @@ export default function NavBar() {
             </Stack>
           </Flex>
         </Flex>
-
-        <Stack
-          flex={{ base: 1, md: 0 }}
-          justify="flex-end"
-          direction="row"
-          spacing={3}
-        >
-          <CartDrawer />
-          <Button
-            as="a"
-            fontSize="sm"
-            fontWeight={600}
-            variant="link"
-            href="/login"
-            bg={""}
-            color={"gray.800"}
-            padding={"5px 20px 5px 20px"}
-            _hover={{
-              bg: "whiteAlpha.500",
-            }}
-          >
-            Login
-          </Button>
-          <Button
-            as="a"
-            href="/signup"
-            display={{ base: "none", md: "inline-flex" }}
-            fontSize="sm"
-            fontWeight={600}
-            color="gray.800"
-            bg=""
-            _hover={{
-              bg: "whiteAlpha.500",
-            }}
-          >
-            Sign Up
-          </Button>
-        </Stack>
+        {/* login + signup + cart */}
+        {isLoggedIn ? (
+          <CartLogout onLogoutClick={onLogoutClick} />
+        ) : (
+          <CartLoginSignup />
+        )}
       </Flex>
     </Box>
   );

--- a/src/components/cart/CartDrawer.jsx
+++ b/src/components/cart/CartDrawer.jsx
@@ -21,7 +21,7 @@ import { BiCart } from "react-icons/bi";
 import { useNavigate } from "react-router-dom";
 
 const CartIcon = () => {
-  return <Icon w={6} h={6} as={BiCart} />;
+  return <Icon w={7} h={7} as={BiCart} />;
 };
 
 const EmptyCartText = () => {

--- a/src/index.css
+++ b/src/index.css
@@ -28,7 +28,6 @@ body,
   position: relative;
   margin: 0;
   padding: 0;
-  overflow: hidden;
   outline: none;
   width: 100vw;
   height: 100vh;


### PR DESCRIPTION
## Changes
- implement profile icon menu for dropdown menu to select logout 
- integrate logout with backend
- fixed an issue where scrolling was disabled
- to be ran in tandem with https://github.com/Nyx92/3D-Model-Ecommerce-Backend/pull/12

## How to test
- login as a seeded user
- expect sign up and login to be replaced with profile icon
- select profile icon, should open a dropdown menu to select logout
- select logout, expect user and loggedInHash cookie to cleared

## Known Issues
- ideally should wait for https://github.com/Nyx92/3D-Model-Ecommerce-Frontend/pull/16 to be merged before this one goes in

## Screenshots (if any)
![image](https://user-images.githubusercontent.com/30279812/197398116-0169ace8-3abe-4fe1-857f-79593aab5aff.png)

